### PR TITLE
Added rubocop config.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Layout/LineLength:
+  Max: 100


### PR DESCRIPTION
You can add more to this config, for now it just specifies that the maximum line length is 100 (opposed to the default 80, which is super short)